### PR TITLE
fix: draw DrawableButton background transparent to avoid corner bleed

### DIFF
--- a/source/UI/DevPianoLookAndFeel.cpp
+++ b/source/UI/DevPianoLookAndFeel.cpp
@@ -167,6 +167,19 @@ void DevPianoLookAndFeel::drawToggleButton(juce::Graphics& g, juce::ToggleButton
 }
 
 // ============================================================================
+//  drawDrawableButton
+// ============================================================================
+void DevPianoLookAndFeel::drawDrawableButton(juce::Graphics& g, juce::DrawableButton& /*button*/, bool /*highlighted*/,
+                                             bool /*down*/) {
+    // ImageFitted 图标按钮（transport 四键、settings 齿轮）的背景与边框由
+    // JIVE BackgroundCanvas 绘制（圆角、含伪状态配色）。必须覆盖 V2 默认
+    // 实现：否则 toggle 状态下 fillAll(backgroundOnColourId) 会在按钮圆角
+    // 外露出一个直角底色（LAF ColourScheme highlightedFill = primary 蓝，
+    // 播放/录制中 setLatched 置 toggle 时可见）。
+    g.fillAll(juce::Colours::transparentBlack);
+}
+
+// ============================================================================
 //  drawComboBox
 // ============================================================================
 void DevPianoLookAndFeel::drawComboBox(juce::Graphics& g, int width, int height, bool /* isButtonDown */, int buttonX,

--- a/source/UI/DevPianoLookAndFeel.h
+++ b/source/UI/DevPianoLookAndFeel.h
@@ -16,6 +16,7 @@ public:
     // ── Drawing overrides ──
     void drawButtonBackground(juce::Graphics&, juce::Button&, const juce::Colour& bg, bool highlighted,
                               bool down) override;
+    void drawDrawableButton(juce::Graphics&, juce::DrawableButton&, bool highlighted, bool down) override;
     void drawToggleButton(juce::Graphics&, juce::ToggleButton&, bool highlighted, bool down) override;
     void drawComboBox(juce::Graphics&, int w, int h, bool down, int bx, int by, int bw, int bh,
                       juce::ComboBox&) override;


### PR DESCRIPTION
ImageFitted DrawableButtons (transport record/play/stop/back, settings gear) paint through LookAndFeel_V2::drawDrawableButton, which fillAlls the button bounds with backgroundOnColourId when toggled. Because DevPianoLookAndFeel defines highlightedFill = primary (#00C8F0), latched transport buttons (play/record during playback/recording) rendered a sharp blue rectangle behind the rounded JIVE background, visible outside the four corners. Override drawDrawableButton to paint nothing: the rounded background and borders come from the JIVE BackgroundCanvas.