### PR TITLE
refactor: consolidate shared JIVE layout and component helpers into JiveUtils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ target_sources(devpiano PRIVATE
     source/UI/jive/LayoutModel.h
     source/UI/jive/JiveModalDialog.cpp
     source/UI/jive/JiveModalDialog.h
+    source/UI/jive/JiveUtils.h
 )
 # ========================================================
 # 4.1 静态资产二进制打包（JIVE 样式表、设计 Token 与语言包）
@@ -317,6 +318,7 @@ if (BUILD_TESTS)
         source/UI/jive/LayoutModel.h
         source/UI/jive/JiveModalDialog.cpp
         source/UI/jive/JiveModalDialog.h
+        source/UI/jive/JiveUtils.h
         source/UI/jive/DesignTokens.cpp
         source/UI/jive/DesignTokens.h
         source/UI/DevPianoLookAndFeel.cpp

--- a/source/Export/WavExportTask.cpp
+++ b/source/Export/WavExportTask.cpp
@@ -5,30 +5,10 @@
 #include "Recording/WavFileExporter.h"
 #include "UI/jive/DesignTokens.h"
 #include "UI/jive/JiveModalDialog.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
 
 namespace {
-
-void clearJiveStyleSheets(juce::Component* comp) {
-    if (comp == nullptr) {
-        return;
-    }
-    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
-        clearJiveStyleSheets(comp->getChildComponent(i));
-    }
-    if (comp->getProperties().contains("style-sheet")) {
-        comp->getProperties().remove("style-sheet");
-    }
-}
-
-void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
-    if (auto component = item.getComponent()) {
-        components.push_back(std::move(component));
-    }
-    for (auto* child : item.getChildren()) {
-        collectJiveComponents(*child, components);
-    }
-}
 
 struct ProgressContentWrapper final : public juce::Component {
     ProgressContentWrapper(std::unique_ptr<::jive::GuiItem> item, std::unique_ptr<::jive::Interpreter> interp,
@@ -46,12 +26,7 @@ struct ProgressContentWrapper final : public juce::Component {
     }
 
     ~ProgressContentWrapper() override {
-        if (rootItem != nullptr) {
-            std::vector<std::shared_ptr<juce::Component>> jiveComponents;
-            collectJiveComponents(*rootItem, jiveComponents);
-            clearJiveStyleSheets(rootItem->getComponent().get());
-            rootItem.reset();
-        }
+        devpiano::ui::jive::safeCleanupJiveTree(rootItem);
         interpreter.reset();
     }
 
@@ -182,6 +157,10 @@ bool WavExportTask::runThread() {
         juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
     }
 #else
+    // DevPiano is a desktop application where JUCE_MODAL_LOOPS_PERMITTED is required
+    // for nested progress dialog dispatch loop.
+    jassertfalse;
+    DP_LOG_ERROR("[Export] WAV export requires JUCE_MODAL_LOOPS_PERMITTED=1");
     while (isThreadRunning()) {
         juce::Thread::sleep(10);
     }

--- a/source/Settings/SettingsComponent.h
+++ b/source/Settings/SettingsComponent.h
@@ -7,58 +7,12 @@
 #include "Settings/SettingsModel.h"
 #include "Settings/jive/SettingsLayoutModel.h"
 #include "UI/jive/DesignTokens.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
 
-// ============================================================================
-// Helper functions for safe JIVE Component Tree traversal and cleanup
-// ============================================================================
-
 namespace {
-
-inline juce::Component* findComponentById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return root.getComponent().get();
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* found = findComponentById(*child, id)) {
-            return found;
-        }
-    }
-    return nullptr;
-}
-
-inline void clearJiveStyleSheets(juce::Component* comp) {
-    if (comp == nullptr) {
-        return;
-    }
-    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
-        clearJiveStyleSheets(comp->getChildComponent(i));
-    }
-    if (comp->getProperties().contains("style-sheet")) {
-        comp->getProperties().remove("style-sheet");
-    }
-}
-
-inline void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
-    if (auto component = item.getComponent()) {
-        components.push_back(std::move(component));
-    }
-    for (auto* child : item.getChildren()) {
-        collectJiveComponents(*child, components);
-    }
-}
-
-inline void safeCleanupJiveTree(std::unique_ptr<::jive::GuiItem>& rootItem) {
-    if (rootItem != nullptr) {
-        std::vector<std::shared_ptr<juce::Component>> jiveComponents;
-        collectJiveComponents(*rootItem, jiveComponents);
-        clearJiveStyleSheets(rootItem->getComponent().get());
-        rootItem.reset();
-    }
-}
-
+using namespace devpiano::ui::jive;
 } // namespace
-
 // ============================================================================
 /// Settings Window Content Component
 ///

--- a/source/Settings/jive/SettingsLayoutModel.cpp
+++ b/source/Settings/jive/SettingsLayoutModel.cpp
@@ -353,16 +353,5 @@ juce::ValueTree makeSettingsLayoutTree() {
 
     return root;
 }
-::jive::GuiItem* findGuiItemById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return &root;
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* found = findGuiItemById(*child, id)) {
-            return found;
-        }
-    }
-    return nullptr;
-}
 
 } // namespace devpiano::ui::jive

--- a/source/Settings/jive/SettingsLayoutModel.h
+++ b/source/Settings/jive/SettingsLayoutModel.h
@@ -2,7 +2,7 @@
 
 #include <JuceHeader.h>
 
-#include <jive_layouts/jive_layouts.h>
+#include "UI/jive/JiveUtils.h"
 
 namespace devpiano::ui::jive {
 
@@ -32,8 +32,5 @@ namespace devpiano::ui::jive {
 /// Full Settings Panel layout tree: combines Audio, Key Signature,
 /// Keyboard Display, Diagnostics, and Save Action into a scrollable column.
 [[nodiscard]] juce::ValueTree makeSettingsLayoutTree();
-
-/// Helper: find a GuiItem with the specified ID property within the tree.
-[[nodiscard]] ::jive::GuiItem* findGuiItemById(::jive::GuiItem& root, const juce::String& id);
 
 } // namespace devpiano::ui::jive

--- a/source/UI/KeyBindingEditDialog.cpp
+++ b/source/UI/KeyBindingEditDialog.cpp
@@ -8,10 +8,11 @@
 #include "UI/ColourSwatchButton.h"
 #include "UI/jive/DesignTokens.h"
 #include "UI/jive/JiveModalDialog.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
 
 namespace {
-
+using namespace devpiano::ui::jive;
 inline juce::ValueTree node(const juce::Identifier& type, const juce::String& id = {}) {
     auto t = juce::ValueTree(type);
     if (id.isNotEmpty()) {
@@ -66,13 +67,6 @@ inline juce::ValueTree settingRow(const juce::String& labelStr, const juce::Valu
 
     row.appendChild(controlNode, nullptr);
     return row;
-}
-
-inline juce::Component* findComponentById(::jive::GuiItem& root, const juce::String& id) {
-    if (auto* item = devpiano::ui::jive::JiveModalDialog::findGuiItemById(root, id)) {
-        return item->getComponent().get();
-    }
-    return nullptr;
 }
 
 const std::array<juce::Colour, 8> paletteColours {

--- a/source/UI/jive/JiveModalDialog.cpp
+++ b/source/UI/jive/JiveModalDialog.cpp
@@ -1,45 +1,12 @@
 #include "UI/jive/JiveModalDialog.h"
 
 #include "UI/jive/DesignTokens.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
 
 namespace devpiano::ui::jive {
 
 namespace {
-
-// ============================================================================
-// JIVE Component Tree Safety Teardown Helpers
-// ============================================================================
-
-void clearJiveStyleSheets(juce::Component* comp) {
-    if (comp == nullptr) {
-        return;
-    }
-    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
-        clearJiveStyleSheets(comp->getChildComponent(i));
-    }
-    if (comp->getProperties().contains("style-sheet")) {
-        comp->getProperties().remove("style-sheet");
-    }
-}
-
-void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
-    if (auto component = item.getComponent()) {
-        components.push_back(std::move(component));
-    }
-    for (auto* child : item.getChildren()) {
-        collectJiveComponents(*child, components);
-    }
-}
-
-void safeCleanupJiveTree(std::unique_ptr<::jive::GuiItem>& rootItem) {
-    if (rootItem != nullptr) {
-        std::vector<std::shared_ptr<juce::Component>> jiveComponents;
-        collectJiveComponents(*rootItem, jiveComponents);
-        clearJiveStyleSheets(rootItem->getComponent().get());
-        rootItem.reset();
-    }
-}
 
 // ============================================================================
 // ValueTree Node Helpers
@@ -264,42 +231,6 @@ private:
 // ============================================================================
 // Public JiveModalDialog Methods
 // ============================================================================
-
-::jive::GuiItem* JiveModalDialog::findGuiItemById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return &root;
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* found = findGuiItemById(*child, id)) {
-            return found;
-        }
-    }
-    return nullptr;
-}
-
-juce::Button* JiveModalDialog::findButtonById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return dynamic_cast<juce::Button*>(root.getComponent().get());
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* b = findButtonById(*child, id)) {
-            return b;
-        }
-    }
-    return nullptr;
-}
-
-juce::TextEditor* JiveModalDialog::findTextEditorById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return dynamic_cast<juce::TextEditor*>(root.getComponent().get());
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* ed = findTextEditorById(*child, id)) {
-            return ed;
-        }
-    }
-    return nullptr;
-}
 
 void JiveModalDialog::launchCustom(const LaunchOptions& options) {
     juce::DialogWindow::LaunchOptions opts;

--- a/source/UI/jive/JiveModalDialog.h
+++ b/source/UI/jive/JiveModalDialog.h
@@ -5,7 +5,7 @@
 #include <functional>
 #include <optional>
 
-#include <jive_layouts/jive_layouts.h>
+#include "UI/jive/JiveUtils.h"
 
 namespace devpiano::ui::jive {
 
@@ -95,9 +95,15 @@ public:
                                                             const juce::String& cancelText = TRANS("Cancel"));
     // ── Component Retrieval Helpers ──
 
-    [[nodiscard]] static ::jive::GuiItem* findGuiItemById(::jive::GuiItem& root, const juce::String& id);
-    [[nodiscard]] static juce::Button* findButtonById(::jive::GuiItem& root, const juce::String& id);
-    [[nodiscard]] static juce::TextEditor* findTextEditorById(::jive::GuiItem& root, const juce::String& id);
+    [[nodiscard]] static ::jive::GuiItem* findGuiItemById(::jive::GuiItem& root, const juce::String& id) {
+        return devpiano::ui::jive::findGuiItemById(root, id);
+    }
+    [[nodiscard]] static juce::Button* findButtonById(::jive::GuiItem& root, const juce::String& id) {
+        return devpiano::ui::jive::findButtonById(root, id);
+    }
+    [[nodiscard]] static juce::TextEditor* findTextEditorById(::jive::GuiItem& root, const juce::String& id) {
+        return devpiano::ui::jive::findTextEditorById(root, id);
+    }
 
 private:
     JUCE_DECLARE_NON_COPYABLE(JiveModalDialog)

--- a/source/UI/jive/JiveUtils.h
+++ b/source/UI/jive/JiveUtils.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+#include <memory>
+#include <vector>
+
+#include <jive_layouts/jive_layouts.h>
+
+namespace devpiano::ui::jive {
+
+// ============================================================================
+// JIVE Component Tree Safety & Teardown Helpers (ERR-009 / Lifetime Safety)
+// ============================================================================
+
+/// Recursively removes style-sheet properties from a component and its children
+/// before GuiItem destruction, preventing dangling component interaction listeners.
+inline void clearJiveStyleSheets(juce::Component* comp) {
+    if (comp == nullptr) {
+        return;
+    }
+    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
+        clearJiveStyleSheets(comp->getChildComponent(i));
+    }
+    if (comp->getProperties().contains("style-sheet")) {
+        comp->getProperties().remove("style-sheet");
+    }
+}
+
+/// Recursively collects shared pointers to all JUCE Components in a GuiItem hierarchy.
+inline void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
+    if (auto component = item.getComponent()) {
+        components.push_back(std::move(component));
+    }
+    for (auto* child : item.getChildren()) {
+        collectJiveComponents(*child, components);
+    }
+}
+
+/// Performs safe, ordered destruction of a JIVE GuiItem tree to ensure
+/// components outlive style sheets (preventing UAF / double-free on teardown).
+inline void safeCleanupJiveTree(std::unique_ptr<::jive::GuiItem>& rootItem) {
+    if (rootItem != nullptr) {
+        std::vector<std::shared_ptr<juce::Component>> jiveComponents;
+        collectJiveComponents(*rootItem, jiveComponents);
+        clearJiveStyleSheets(rootItem->getComponent().get());
+        rootItem.reset();
+    }
+}
+
+// ============================================================================
+// JIVE Element & ValueTree ID Lookup Helpers
+// ============================================================================
+
+/// Finds a GuiItem with the specified ID property within the GuiItem hierarchy.
+[[nodiscard]] inline ::jive::GuiItem* findGuiItemById(::jive::GuiItem& root, const juce::String& id) {
+    if (root.state.getProperty("id").toString() == id) {
+        return &root;
+    }
+    for (auto* child : root.getChildren()) {
+        if (auto* found = findGuiItemById(*child, id)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+/// Finds the underlying JUCE Component of a GuiItem with the specified ID property.
+[[nodiscard]] inline juce::Component* findComponentById(::jive::GuiItem& root, const juce::String& id) {
+    if (auto* item = findGuiItemById(root, id)) {
+        return item->getComponent().get();
+    }
+    return nullptr;
+}
+
+/// Finds a juce::Button component of a GuiItem with the specified ID property.
+[[nodiscard]] inline juce::Button* findButtonById(::jive::GuiItem& root, const juce::String& id) {
+    return dynamic_cast<juce::Button*>(findComponentById(root, id));
+}
+
+/// Finds a juce::TextEditor component of a GuiItem with the specified ID property.
+[[nodiscard]] inline juce::TextEditor* findTextEditorById(::jive::GuiItem& root, const juce::String& id) {
+    return dynamic_cast<juce::TextEditor*>(findComponentById(root, id));
+}
+
+/// Finds a ValueTree node with the specified ID property in a ValueTree hierarchy.
+[[nodiscard]] inline juce::ValueTree findNodeById(const juce::ValueTree& root, const juce::String& id) {
+    if (root.getProperty("id").toString() == id) {
+        return root;
+    }
+    for (const auto child : root) {
+        if (auto found = findNodeById(child, id); found.isValid()) {
+            return found;
+        }
+    }
+    return {};
+}
+
+} // namespace devpiano::ui::jive

--- a/source/tests/JiveModalDialogTest.cpp
+++ b/source/tests/JiveModalDialogTest.cpp
@@ -5,51 +5,11 @@
 #include "UI/PresetDialogs.h"
 #include "UI/jive/DesignTokens.h"
 #include "UI/jive/JiveModalDialog.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
+
 namespace {
-
-void clearJiveStyleSheets(juce::Component* comp) {
-    if (comp == nullptr) {
-        return;
-    }
-    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
-        clearJiveStyleSheets(comp->getChildComponent(i));
-    }
-    if (comp->getProperties().contains("style-sheet")) {
-        comp->getProperties().remove("style-sheet");
-    }
-}
-
-void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
-    if (auto component = item.getComponent()) {
-        components.push_back(std::move(component));
-    }
-    for (auto* child : item.getChildren()) {
-        collectJiveComponents(*child, components);
-    }
-}
-
-void safeCleanupJiveTree(std::unique_ptr<::jive::GuiItem>& rootItem) {
-    if (rootItem != nullptr) {
-        std::vector<std::shared_ptr<juce::Component>> jiveComponents;
-        collectJiveComponents(*rootItem, jiveComponents);
-        clearJiveStyleSheets(rootItem->getComponent().get());
-        rootItem.reset();
-    }
-}
-
-juce::ValueTree findNodeById(const juce::ValueTree& root, const juce::String& id) {
-    if (root.getProperty("id").toString() == id) {
-        return root;
-    }
-    for (auto child : root) {
-        if (auto found = findNodeById(child, id); found.isValid()) {
-            return found;
-        }
-    }
-    return {};
-}
-
+using namespace devpiano::ui::jive;
 } // namespace
 
 class JiveModalDialogTest final : public juce::UnitTest {

--- a/source/tests/SettingsLayoutModelTest.cpp
+++ b/source/tests/SettingsLayoutModelTest.cpp
@@ -4,64 +4,11 @@
 #include "Settings/SettingsModel.h"
 #include "Settings/jive/SettingsLayoutModel.h"
 #include "UI/jive/DesignTokens.h"
+#include "UI/jive/JiveUtils.h"
 #include "UI/jive/StyleCatalog.h"
 
 namespace {
-
-void clearJiveStyleSheets(juce::Component* comp) {
-    if (comp == nullptr) {
-        return;
-    }
-    for (int i = 0; i < comp->getNumChildComponents(); ++i) {
-        clearJiveStyleSheets(comp->getChildComponent(i));
-    }
-    if (comp->getProperties().contains("style-sheet")) {
-        comp->getProperties().remove("style-sheet");
-    }
-}
-
-void collectJiveComponents(::jive::GuiItem& item, std::vector<std::shared_ptr<juce::Component>>& components) {
-    if (auto component = item.getComponent()) {
-        components.push_back(std::move(component));
-    }
-    for (auto* child : item.getChildren()) {
-        collectJiveComponents(*child, components);
-    }
-}
-
-void safeCleanupJiveTree(std::unique_ptr<::jive::GuiItem>& rootItem) {
-    if (rootItem != nullptr) {
-        std::vector<std::shared_ptr<juce::Component>> jiveComponents;
-        collectJiveComponents(*rootItem, jiveComponents);
-        clearJiveStyleSheets(rootItem->getComponent().get());
-        rootItem.reset();
-    }
-}
-
-juce::ValueTree findNodeById(const juce::ValueTree& root, const juce::String& id) {
-    if (root.getProperty("id").toString() == id) {
-        return root;
-    }
-    for (auto child : root) {
-        if (auto found = findNodeById(child, id); found.isValid()) {
-            return found;
-        }
-    }
-    return {};
-}
-
-juce::Component* findComponentById(::jive::GuiItem& root, const juce::String& id) {
-    if (root.state.getProperty("id").toString() == id) {
-        return root.getComponent().get();
-    }
-    for (auto* child : root.getChildren()) {
-        if (auto* found = findComponentById(*child, id)) {
-            return found;
-        }
-    }
-    return nullptr;
-}
-
+using namespace devpiano::ui::jive;
 } // namespace
 
 class SettingsLayoutModelTest final : public juce::UnitTest {


### PR DESCRIPTION
## Summary

This PR consolidates duplicated JIVE component tree cleanup and element lookup functions into a single shared utility header `source/UI/jive/JiveUtils.h` and adds defense-in-depth handling for `WavExportTask` modal loop dependencies.

### Changes

1. **New `source/UI/jive/JiveUtils.h`**
   - `clearJiveStyleSheets`: Recursively removes style sheets to prevent dangling interaction listeners.
   - `collectJiveComponents`: Collects owned references to JUCE components across the JIVE hierarchy.
   - `safeCleanupJiveTree`: Standardized, safe destruction order ensuring components outlive style sheets (ERR-009).
   - `findGuiItemById`, `findComponentById`, `findButtonById`, `findTextEditorById`, `findNodeById`: Type-safe component and ValueTree lookups by ID.

2. **Consolidation Across 8 Source & Test Files**
   - Replaced duplicate static/anonymous implementations in `SettingsComponent.h`, `SettingsLayoutModel.h/.cpp`, `JiveModalDialog.h/.cpp`, `WavExportTask.cpp`, `KeyBindingEditDialog.cpp`, `JiveModalDialogTest.cpp`, and `SettingsLayoutModelTest.cpp`.
   - Net reduction of **~180 lines** of duplicate boilerplate code.

3. **`WavExportTask` Modal Loop Defense**
   - Added `jassertfalse` and error logging in the `#else` branch of `runThread()` to clearly flag targets attempting non-modal dispatch on desktop.

### Verification

- **Code Formatting**: `clang-format` check passed (0 violations).
- **Unit Tests**: WSL ctest passing (11,538 assertions passed, 0 failed).
- **WSL & Windows Builds**: `wsl-build` and `win-build` (MSVC `windows-msvc-debug`) both completed with 0 warnings, 0 errors.